### PR TITLE
(maint) Upgrade to Nom 2.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Ryan Senior <ryan.senior@puppet.com>", "Andrew Roetker <andrew.roetker@puppet.com"]
 
 [dependencies]
-nom = "~1.2.2"
+nom = "^2.0"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,7 +18,7 @@ pub enum JsonValue<'a> {
 named!(quoted_str<&str>,
        map_res!(delimited!(char!('"'),
                            escaped!(call!(alpha), '\\',
-                                    is_a_bytes!(&b"\"n\\"[..])),
+                                    is_a!(&b"\"n\\"[..])),
                            char!('"')),
                 str::from_utf8));
 
@@ -59,7 +59,7 @@ named!(json_null<JsonValue>,
 
 macro_rules! multispaced (
     ($i:expr, $submac:ident!( $($args:tt)* )) => (
-        delimited!($i, opt!(multispace), $submac!($($args)*), opt!(multispace));
+        delimited!($i, opt!(complete!(multispace)), $submac!($($args)*), opt!(complete!(multispace)));
     );
     ($i:expr, $f:expr) => (
         multispaced!($i, call!($f));


### PR DESCRIPTION
This commit upgrades the nom dependency to 2.0.1 and wraps multispace in
a complete! call now that multispace returns an Incomplete rather than
error if it doesn't succeed.